### PR TITLE
Preserve config AUTONOMY when CLI flag is not provided; add --no-autonomy

### DIFF
--- a/orchestrateur.py
+++ b/orchestrateur.py
@@ -347,7 +347,7 @@ def main():
     global VERBOSE, REASONING_LEVEL, EXEC_TIMEOUT, MAX_RETRIES, MODEL_NAME, MODEL_NATIVE_TOOLS, MODEL_JSON_FALLBACK, AUTONOMY
     
     parser = argparse.ArgumentParser(
-        description="Ollama Code-Assistant (utilisez --autonomy pour enchaîner les tool calls sans confirmation)"
+        description="Ollama Code-Assistant (utilisez --autonomy/--no-autonomy pour piloter l'enchaînement automatique des tool calls)"
     )
     parser.add_argument(
         "directory",
@@ -390,8 +390,19 @@ def main():
     )
     parser.add_argument(
         "--autonomy",
-        action="store_true",
-        help="Active l'autonomie: le modèle enchaîne automatiquement les tool calls sans attente utilisateur",
+        action="store_const",
+        const=True,
+        default=None,
+        dest="autonomy",
+        help="Force l'autonomie: le modèle enchaîne automatiquement les tool calls sans attente utilisateur",
+    )
+    parser.add_argument(
+        "--no-autonomy",
+        action="store_const",
+        const=False,
+        default=None,
+        dest="autonomy",
+        help="Désactive l'autonomie: chaque étape nécessite une validation utilisateur",
     )
     args = parser.parse_args()
     VERBOSE = args.verbose
@@ -399,7 +410,8 @@ def main():
     EXEC_TIMEOUT = args.exec_timeout
     MAX_RETRIES = args.max_retries
     MODEL_NAME = args.model
-    AUTONOMY = args.autonomy
+    if args.autonomy is not None:
+        AUTONOMY = args.autonomy
 
     compat = MODEL_COMPAT.get(MODEL_NAME, DEFAULT_MODEL_COMPAT)
     MODEL_NATIVE_TOOLS = compat.get("native_tools", DEFAULT_MODEL_COMPAT["native_tools"])
@@ -459,6 +471,7 @@ def main():
     console.print(
         f"[dim]Compat tools natifs : {MODEL_NATIVE_TOOLS} | JSON fallback : {MODEL_JSON_FALLBACK}[/dim]"
     )
+    console.print(f"[dim]Autonomie effective : {AUTONOMY}[/dim]")
     files_data = collect_files(work_dir)
     if not files_data:
         console.print(


### PR DESCRIPTION
### Motivation
- Éviter d'écraser systématiquement la valeur `AUTONOMY` provenant de `config.settings` quand l'utilisateur ne passe aucune option CLI liée à l'autonomie.
- Permettre à l'utilisateur de forcer explicitement l'autonomie (`True`/`False`) tout en conservant le comportement par défaut défini en configuration lorsque l'option n'est pas fournie.

### Description
- Remplacement de l'ancienne option `--autonomy` (boolean implicite) par deux options explicites partageant la même destination : `--autonomy` (`const=True`) et `--no-autonomy` (`const=False`) avec `default=None` pour ne pas écraser la config par défaut.
- Ajout de la logique post-parse qui n'affecte `AUTONOMY` que si `args.autonomy is not None`, sinon la valeur issue de `config.settings` est conservée.
- Mise à jour du message de description du parser et ajout de l'affichage de démarrage `Autonomie effective : {AUTONOMY}` pour faciliter le debug utilisateur.

### Testing
- `python -m py_compile orchestrateur.py` a été exécuté et a réussi.`
- Lancement runtime de `orchestrateur.py` pour vérifier l'affichage a été tenté mais a échoué pour cause de dépendance manquante (`ModuleNotFoundError: No module named 'ollama'`), donc le comportement à l'exécution n'a pas pu être validé end-to-end dans cet environnement.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f338358cc8324944c1be9e396885e)